### PR TITLE
add default for variable 'suseconnect_remove_subscriptions'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ suseconnect_products: []
 suseconnect_status: {}
 suseconnect_reregister: False
 suseconnect_register_only_products: False
+
+# do not remove subscriptions by default
+suseconnect_remove_subscriptions: false


### PR DESCRIPTION
add default in case the variable 'suseconnect_remove_subscriptions' is not defined

Avoids this error:
```
fatal: [some-hostname]: FAILED! => {"msg": "The conditional check 'suseconnect_remove_subscriptions' failed. The error was: error while evaluating conditional (suseconnect_remove_subs
criptions): 'suseconnect_remove_subscriptions' is undefined\n\nThe error appears to be in '/home/kastl/Ceph/Testen/SLES15/b1-systems.suseconnect/tasks/main.yml': line 65, column 3, but may\
nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Remove Subscriptions\n  ^ here\n"} 
```