### PR TITLE
tasks/main.yml: fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
     {{- item['value']['version'] | default(ansible_distribution_version) }}/
     {{- item['value']['arch'] | default(ansible_machine) }}
   when:
-    - suseconnect_remove_subscriptions
+    - suseconnect_remove_subscriptions | bool
     - item['key'] not in suseconnect_product_list
     - suseconnect_product_list | length > 0
   with_dict: "{{ suseconnect_status }}"


### PR DESCRIPTION
fixes #5

```
TASK [b1-systems-ansible-role-suseconnect : Remove Subscriptions] ***************************************************************************************************************************
[DEPRECATION WARNING]: evaluating 'suseconnect_remove_subscriptions' as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also
see CONDITIONAL_BARE_VARS configuration toggle. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```