### PR TITLE
tasks/main.yml: make deregistering idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,3 +78,4 @@
   command: "{{ suseconnect_binary }} -d"
   when:
     - suseconnect_product_list | length == 0
+    - suseconnect_status['SLES']['status'] != 'Not Registered'


### PR DESCRIPTION
Do not fail on deregistering when the system is already deregistered.

fixes #6 
