### PR TITLE
tasks/main.yml: do not trim whitespace after the '-p' flag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
 - name: Add Subscriptions
   command: |
     {{ suseconnect_binary }} -p
-    {{- item['product'] | default(ansible_distribution) }}/
+    {{ item['product'] | default(ansible_distribution) }}/
     {{- item['version'] | default(ansible_distribution_version) }}/
     {{- item['arch'] | default(ansible_machine) }}
     {%- if item['key'] is defined %} -r {{ item['key'] }}{% endif %}


### PR DESCRIPTION
trimming the whitespace will error out on SLES15 SP4:

```
"stderr_lines": ["flag provided but not defined: -pSLES/15.4/x86_64"]
```